### PR TITLE
Improved "make release" recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,14 +133,15 @@ endif
 	@git diff --color $^
 	@echo
 	
-	@read -p "Does the above 'git diff' look OK? ([y]/n, or Ctrl+C) "; \
-	if [[ -n $$REPLY || $$REPLY =~ ^[Nn] ]]; then \
+	@read -p "Does the above 'git diff' look OK? (y/[n], or Ctrl+C) "; \
+	if [[ -z $$REPLY || $$REPLY =~ ^[Nn] ]]; then \
 		echo; \
 		echo "$(YELLOW)(**) NOTE$(RESET) - reverting changes to: $<" >&2; \
 		git checkout $^; \
 		exit 1; \
 	fi
 	
+	@echo
 	@# create a new commit log entry for the release
 	git add $^
 	@#      ^^ means "the names of all the prerequisites"

--- a/Makefile
+++ b/Makefile
@@ -1,40 +1,55 @@
-PKGNAME=NextGenAligner
-MODNAME=$(shell tr 'A-Z ' 'a-z_' <<<"$(PKGNAME)")
-SCRIPTNAME=$(PKGNAME)
+########################################################################
+##                                                                    ##
+##   Makefile for NextGenAligner                                      ##
+##                                                                    ##
+##   Usage:    make       --or--                                      ##
+##             make help                                              ##
+##                                                                    ##
+########################################################################
+
+PKGNAME = NextGenAligner
+# make the name of the module all lower-case
+MODNAME = $(shell tr 'A-Z ' 'a-z_' <<<"$(PKGNAME)")
+SCRIPTNAME = $(PKGNAME)
+README = README.txt
 # get the package version from the script itself
 PKGVER=$(shell sed -n "s/^\(my \$$version  *=  *\)'\(.*\)';/\2/p" $(SCRIPTNAME))
 # printed in the 'make help' output
 READMEURL=https://github.com/MarioPujato/NextGenAligner\#readme
 
-LABROOT=/data/weirauchlab
+# this can be overridden by running 'PREFIX=/some/other/dir make'
+PREFIX ?= /usr/local
 # where "local" modules are installed (modules for software *we* wrote)
-MODULEROOT=$(LABROOT)/local/modules
+MODULEROOT = $(PREFIX)/modules
 # "root" dir where MARIO binaries & other supporting files will be installed
-MODULEDIR=$(MODULEROOT)/$(MODNAME)/$(PKGVER)
+MODULEDIR = $(MODULEROOT)/$(MODNAME)/$(PKGVER)
 # install these into $(MODULEDIR)/bin
-EXECUTABLES=$(SCRIPTNAME)
+EXECUTABLES = $(SCRIPTNAME)
 
 # where 'modulefile' will be installed to with 'make install-modulefile'
-MODULEDESTFILE=$(MODULEROOT)/modulefiles/$(MODNAME)/$(PKGVER)
+MODULEDESTFILE = $(MODULEROOT)/modulefiles/$(MODNAME)/$(PKGVER)
 # the name of the Environment Modules modulefile in the c.w.d.
-MODULEFILE=modulefile.tcl
+MODULEFILE = modulefile.tcl
 # today's date in MMDDYY format
-TODAY=$(shell date +%m%d%y)
+TODAY = $(shell date +%m%d%y)
+# set to 'v' if you want your Git tags to be 'v1.0.0' instead of '1.0.0'
+TAGPREFIX = 
 # use the Bash shell (always)
-SHELL=bash
+SHELL = bash
 
 # ANSI terminal colors (see 'man tput') and
 # https://linuxtidbits.wordpress.com/2008/08/11/output-color-on-bash-scripts/
 #
-# Don't use color if there isn't a $TERM environment variable:
+# Don't set these if there isn't a $TERM environment variable
 ifneq ($(strip $(TERM)),)
-	BOLD=$(shell tput bold)
-	RED=$(shell tput setaf 1)
-	GREEN=$(shell tput setaf 2)
-	BLUE=$(shell tput setaf 4)
-	MAGENTA=$(shell tput setaf 5)
-	UL=$(shell tput sgr 0 1)
-	RESET=$(shell tput sgr0 )
+	BOLD := $(shell tput bold)
+	RED := $(shell tput setaf 1)
+	GREEN := $(shell tput setaf 2)
+	YELLOW := $(shell tput setaf 3)
+	BLUE := $(shell tput setaf 4)
+	MAGENTA := $(shell tput setaf 5)
+	UL := $(shell tput sgr 0 1)
+	RESET := $(shell tput sgr0 )
 endif
 
 help:
@@ -61,59 +76,108 @@ install: install-modulefile
 	for exe in $(EXECUTABLES); do install -m755 $$exe $(MODULEDIR)/bin; done
 
 install-modulefile:
-	# -D = create all components of DEST except the last, copy SOURCE to DEST
+	# installing modulefile to '$(MODULEDESTFILE)'
+	@# -D = create all components of DEST except the last, copy SOURCE to DEST
 	install -D $(MODULEFILE) $(MODULEDESTFILE)
 
 # get VERSION from the environment/command line; use it to update the
-# '$version' variable in the 'MARIO' Perl script as well as the modulefile
-release: $(EXECUTABLES) $(MODULEFILE)
+# '$version' and '$modified' variables in the 'NextGenAligner' Perl script,
+# the README, and the modulefile
+release: $(EXECUTABLES) $(MODULEFILE) $(README)
 ifeq ($(VERSION),)
 	@echo >&2
-	@echo "  $(UL)$(BOLD)$(RED)OH NOES!$(RESET)"
+	@echo "  $(UL)$(BOLD)$(RED)OOPS!$(RESET)"
 	@echo >&2
 	@echo "  Expected a value for VERSION. Try again like this:"
 	@echo >&2
 	@echo "      $(BOLD)make release VERSION=x.y.z$(RESET)" >&2
 	@echo >&2
-	@false
-else
-	@if ! [[ $(VERSION) =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$$ ]]; then \
-		echo "(!!) $(BOLD)$(RED)ERROR$(RESET) - bad version; expected x.y[.z], where x, y, and z are all integers." >&2; \
-		exit 1; \
-	fi
-	@if git status --porcelain | grep .; then \
-		echo "(!!) $(BOLD)$(RED)ERROR$(RESET) - Git working tree is dirty; commit changes and try again." >&2; \
-		exit 1; \
-	fi
-	@if git tag | grep $(VERSION); then \
-		echo "(!!) $(BOLD)$(RED)ERROR$(RESET) - release $(VERSION) already exists." >&2; \
-		exit 1; \
-	fi
-	# replace version string in the Perl script
-	sed -i "s/^\(my \$$version  *=  *\)'\(.*\)';/\1'$(VERSION)';/" $(SCRIPTNAME)
-	# update the modified date in the Perl script
-	sed -i "s/^\(my \$$modified  *=  *\)'\(.*\)';/\1'$(TODAY)';/" $(SCRIPTNAME)
-	# replace version in the modulefile, too
-	sed -i 's/\(set version \)".*"/\1"$(VERSION)"/' $(MODULEFILE)
-	# create a new commit log entry and tag for the release
-	git add $^ && git commit -m'Release v$(VERSION)'
-	@#           ^^ means "the names of all the prerequisites"
-	git tag v$(VERSION)
-	@echo
-	@echo "  $(UL)$(BOLD)$(BLUE)SUPER!$(RESET)"
-	@echo
-	@echo "  Updated '$(SCRIPTNAME)' and '$(MODULEFILE)' from v$(PKGVER) to v$(VERSION)"
-	@echo
-	@echo "  It would be a good idea now to:"
-	@echo
-	@echo "      $(BOLD)make install$(RESET)"
-	@echo
-	@echo "  to update the installed code and Environment Modules modulefile."
-	@echo
-	@echo "  Then push the new tag to your default Git remote, like this:"
-	@echo
-	@echo "      $(BOLD)git push && git push --tags$(RESET)"
-	@echo
-	@echo "  so the new release shows up on GitLab/GitHub."
-	@echo
+	@exit 1
 endif
+	
+	@# don't forget that $'s must be doubled in Makefiles to get a literal '$'
+	@if ! [[ $(VERSION) =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$$ ]]; then \
+		echo "$(BOLD)$(RED)(!!) ERROR$(RESET) - bad version; expected x.y[.z], where x, y, and z are all integers." >&2; \
+		exit 1; \
+	fi
+	
+	@# (re)initialize a git repository (it's harmless if one already exists)
+	@git init &>/dev/null
+	
+	@if git status --porcelain | grep -q .; then \
+		echo "$(BOLD)$(RED)(!!) ERROR$(RESET) - Git working tree is dirty; commit changes and try again." >&2; \
+		echo >&2; \
+		echo "     If this is a brand new repository, do this first:" >&2; \
+		echo >&2; \
+		echo "         $(BOLD)git add . && git commit -m'Initial commit'$(RESET)" >&2; \
+		echo >&2; \
+		exit 1; \
+	fi
+	
+	@if git tag | grep -q $(TAGPREFIX)$(VERSION); then \
+		echo "$(BOLD)$(RED)(!!) ERROR$(RESET) - release $(TAGPREFIX)$(VERSION) already exists." >&2; \
+		exit 1; \
+	fi
+	
+	@# replace version string in the Perl script and README
+	sed -i "s/^\(my \$$version  *=  *\)'\(.*\)';/\1'$(VERSION)';/" $(SCRIPTNAME)
+	sed -i "s/^\(Version:  *\)\(.*\)/\1$(VERSION)/" $(README)
+	@# update the modified date in the Perl script and README
+	sed -i "s/^\(my \$$modified  *=  *\)'\(.*\)';/\1'$(TODAY)';/" $(SCRIPTNAME)
+	sed -i "s/^\(Modified:  *\)\(.*\)/\1$(TODAY)/" $(README)
+	@# replace version in the modulefile, too
+	sed -i 's/\(set version \)".*"/\1"$(VERSION)"/' $(MODULEFILE)
+	
+	@# ask the user if the modifications with 'sed' look OK
+	@# the Makefile variable '$^' means "all dependencies"
+	@git diff --color $^
+	@echo
+	
+	@read -p "Does the above 'git diff' look OK? ([y]/n, or Ctrl+C) "; \
+	if [[ -n $$REPLY || $$REPLY =~ ^[Nn] ]]; then \
+		echo; \
+		echo "$(YELLOW)(**) NOTE$(RESET) - reverting changes to: $<" >&2; \
+		git checkout $^; \
+		exit 1; \
+	fi
+	
+	@# create a new commit log entry for the release
+	git add $^
+	@#      ^^ means "the names of all the prerequisites"
+	git commit -m'Release $(TAGPREFIX)$(VERSION)'
+	@echo
+	
+	@# create a new (lightweight) tag for the release; for an explanation of
+	@# lightweight v. annotated tags, see https://stackoverflow.com/a/4971817
+	@#
+	@# FYI: use 'git show <tag>' to see all the details for a tag/release
+	git tag $(TAGPREFIX)$(VERSION)
+	
+	@echo; \
+	echo "  $(UL)$(BOLD)$(BLUE)SUPER!$(RESET)"; \
+	echo; \
+	echo "  Updated '$(PKGNAME)' from $(TAGPREFIX)$(PKGVER) to $(TAGPREFIX)$(VERSION)"; \
+	echo; \
+	echo "  It would be a good idea now to:"; \
+	echo; \
+	echo "      $(BOLD)make install$(RESET)"; \
+	echo; \
+	echo "  to update the installed version of the code."; \
+	echo; \
+	echo "  Then, push the new tag to your default Git remote, like this:"; \
+	echo; \
+	echo "      $(BOLD)git push && git push --tags$(RESET)"; \
+	echo; \
+	echo "  so that the new release shows up on GitLab / GitHub."; \
+	echo
+
+# basically just a dummy target for now; this removes editor temp files
+# the '-' in front means that make will ignore any error (non-zero exit)
+clean:
+	-rm *~
+
+# prevent make from getting confused if files w/ these names exist on filesys.
+.PHONY: help install release clean
+
+# please leave this intact; prevents Vim from converting spaces to tabs
+# vim: noet ft=make

--- a/NextGenAligner
+++ b/NextGenAligner
@@ -1,5 +1,6 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 use strict;
+use warnings;
 use Cwd;
 use Getopt::Std;
 use Parallel::ForkManager;

--- a/README.txt
+++ b/README.txt
@@ -2,7 +2,7 @@
 NextGenAligner
 Next-Generation sequencing alignment pipeline
 
-Version:    1.4.3
+Version:    1.4.4
 Created:    011017
 Modified:   062619
 Written by: Mario Pujato

--- a/modulefile.tcl
+++ b/modulefile.tcl
@@ -7,7 +7,7 @@
 
 set name "nextgenaligner"
 set proper "Mario's NextGenAligner"
-set version "1.4.0"
+set version "1.4.4"
 set descrip "Standard analysis pipeline for NGS data"
 set homepage "https://github.com/ernstki/NextGenAligner.git"
 set issues "https://github.com/MarioPujato/NextGenAligner/issues"


### PR DESCRIPTION
- `make release` now updates the `README.txt` and gives you a diff showing what was changed
    * you now have the option to abort the changes made by `make release` (reverting changed files to last checked-in versions)
    * also doesn't put `v` in front of the tags anymore (unless you set `TAGPREFIX=v`)
- removed references to Weirauch Lab "LABROOT" in Makefile
- updated version numbers in modulefile and README (to 1.4.4)
- updated shebang line to `#!/usr/bin/env perl` instead of hard-coded Perl interpreter
